### PR TITLE
增加demand展示页面

### DIFF
--- a/lib/mas_env_server/ci_runner.ex
+++ b/lib/mas_env_server/ci_runner.ex
@@ -27,6 +27,11 @@ defmodule MasEnvServer.CiRunner do
           output_str
       end
 
+    MasEnvServer.DemandDb.update_demand_board(task_id, return_report, %{
+      "tree" => code_tree,
+      "content" => code_str
+    })
+
     MasEnvServer.ReportDb.write_report(task_id, return_report)
     {:noreply, state}
   end

--- a/lib/mas_env_server/demand_db.ex
+++ b/lib/mas_env_server/demand_db.ex
@@ -7,17 +7,31 @@ defmodule MasEnvServer.DemandDb do
 
   def handle_cast({:create, {uuid, readme_content, test_map}}, state) do
     # TODO,增加检测，这个函数只做新的demand的增加操作
-    new_state = Map.put(state, uuid, %{"README" => readme_content, "test" => test_map})
+    new_state =
+      Map.put(state, uuid, %{
+        "README" => readme_content,
+        "report" => %{},
+        "source_code" => %{"tree" => "", "content" => test_map}
+      })
+
     {:noreply, new_state}
   end
 
-  def handle_cast({:update, {uuid, readme_content, test_map}}, state) do
+  def handle_cast({:update, {uuid, report, source_code}}, state) do
     # TODO，后续是否需要对给定的demand进行更新
-    {:noreply, state}
+    task_map =
+      Map.get(state, uuid) |> Map.put("report", report) |> Map.put("source_code", source_code)
+
+    new_state = Map.put(state, uuid, task_map)
+    {:noreply, new_state}
   end
 
   def handle_call({:has_key, task_id}, _from, state) do
     {:reply, Map.has_key?(state, task_id), state}
+  end
+
+  def handle_call({:retrieve_all}, _from, state) do
+    {:reply, state, state}
   end
 
   def start_link(args) do
@@ -31,5 +45,13 @@ defmodule MasEnvServer.DemandDb do
 
   def has_task_id(task_id) do
     GenServer.call(:demand_db, {:has_key, task_id})
+  end
+
+  def update_demand_board(task_id, report, source_code) do
+    GenServer.cast(:demand_db, {:update, {task_id, report, source_code}})
+  end
+
+  def get_demand_board() do
+    GenServer.call(:demand_db, {:retrieve_all})
   end
 end

--- a/lib/mas_env_server_web/controllers/page_controller.ex
+++ b/lib/mas_env_server_web/controllers/page_controller.ex
@@ -46,6 +46,14 @@ defmodule MasEnvServerWeb.PageController do
     |> json(return_json)
   end
 
+  def pull_all_demand(conn, _params) do
+    all_demand_record = MasEnvServer.DemandDb.get_demand_board()
+
+    conn
+    |> put_status(:ok)
+    |> json(all_demand_record)
+  end
+
   def get_mas_report_by_id(conn, %{"task_id" => task_id}) do
     result = MasEnvServer.ReportDb.retrieve_report(task_id)
 

--- a/lib/mas_env_server_web/router.ex
+++ b/lib/mas_env_server_web/router.ex
@@ -19,6 +19,7 @@ defmodule MasEnvServerWeb.Router do
 
     get "/", PageController, :home
     post "/demand", PageController, :demand_upload
+    get "/pull", PageController, :pull_all_demand
     post "/push", PageController, :mas_push_src
     get "/result", PageController, :get_mas_report_by_id
   end


### PR DESCRIPTION
# Summary
由于demand数据存在env_server，并且它现在只能等待mas的请求过来获取数据，因此需要有一个api用来获取当前env中有哪些demand